### PR TITLE
Host Chat Server on AWS EC2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,150 @@
+provider "aws" {
+  region  = "us-east-2"
+  # Choose the AWS region where the resources will be created.
+  profile = "chat_admin"
+}
+
+# Create a vpc
+resource "aws_vpc" "chat_vpc" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags                 = {
+    name = "ChatVPC"
+  }
+}
+
+# Create an internet gateway
+resource "aws_internet_gateway" "chat_gw" {
+  vpc_id = aws_vpc.chat_vpc.id
+  tags   = {
+    name = "chat_gw"
+  }
+}
+
+# Create a custom route table
+resource "aws_route_table" "chat_route_table" {
+  vpc_id = aws_vpc.chat_vpc.id
+  tags   = {
+    name = "my_route_table"
+  }
+}
+# create route
+resource "aws_route" "chat_route" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.chat_gw.id
+  route_table_id         = aws_route_table.chat_route_table.id
+}
+
+# create a subnet
+resource "aws_subnet" "chat_subnet" {
+  vpc_id            = aws_vpc.chat_vpc.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = var.availability_zone
+
+  tags = {
+    name = "chat_subnet"
+  }
+}
+
+# associate internet gateway to the route table by using subnet
+resource "aws_route_table_association" "chat_assoc" {
+  subnet_id      = aws_subnet.chat_subnet.id
+  route_table_id = aws_route_table.chat_route_table.id
+}
+
+# create security group to allow ingoing ports
+resource "aws_security_group" "chat_sg" {
+  name        = "chat_server_sg"
+  description = "security group for the EC2 instance of chat server"
+  vpc_id      = aws_vpc.chat_vpc.id
+  ingress     = [
+    {
+      description      = "ssh"
+      from_port        = 22
+      to_port          = 22
+      protocol         = "tcp"
+      cidr_blocks      = ["0.0.0.0/0", aws_vpc.chat_vpc.cidr_block]
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = false
+    },
+    {
+      description      = "TCP access for chat server"
+      from_port        = 4000
+      to_port          = 65535
+      protocol         = "tcp"
+      cidr_blocks      = ["0.0.0.0/0", aws_vpc.chat_vpc.cidr_block]
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = false
+    },
+  ]
+  egress = [
+    {
+      from_port        = 0
+      to_port          = 0
+      protocol         = "-1"
+      cidr_blocks      = ["0.0.0.0/0"]
+      description      = "Outbound traffic rule"
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = false
+    }
+  ]
+  tags = {
+    name = "allow_ssh_and_chat_server"
+  }
+}
+
+# create a network interface with private ip from step 4
+resource "aws_network_interface" "chat_net_interface" {
+  subnet_id       = aws_subnet.chat_subnet.id
+  security_groups = [aws_security_group.chat_sg.id]
+}
+
+# assign a elastic ip to the network interface created in step 7
+resource "aws_eip" "chat_eip" {
+  domain                    = "vpc"
+  network_interface         = aws_network_interface.chat_net_interface.id
+  associate_with_private_ip = aws_network_interface.chat_net_interface.private_ip
+  depends_on                = [
+    aws_internet_gateway.chat_gw, aws_instance.chat_server
+  ]
+}
+
+# Launch an EC2 instance in the subnet with the defined security group.
+resource "aws_instance" "chat_server" {
+  ami               = "ami-0a125f1b5cba564a0"
+  instance_type     = var.instance_type
+  availability_zone = var.availability_zone
+
+  key_name = "ec2_key"
+
+  network_interface {
+    device_index         = 0
+    network_interface_id = aws_network_interface.chat_net_interface.id
+  }
+  user_data = file("${path.module}/setup_server.sh")
+  tags      = {
+    Name = "chat_server"
+  }
+}
+
+output "instance_public_ip" {
+  description = "Public IP address of the EC2 instance"
+  value       = aws_instance.chat_server.private_ip
+}
+
+output "eip" {
+  description = "public Ip of eip"
+  value       = aws_eip.chat_eip.public_ip
+}
+
+output "subnet_id" {
+  description = "private ip(subnet)"
+  value       = aws_subnet.chat_subnet.id
+}

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,7 @@ resource "aws_instance" "chat_server" {
   instance_type     = var.instance_type
   availability_zone = var.availability_zone
 
-  key_name = "ec2_key"
+  key_name = "aws_key"
 
   network_interface {
     device_index         = 0

--- a/setup_client.sh
+++ b/setup_client.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+sudo apt update -y
+sudo apt install -y gcc gdb make cmake clang-format \
+clang-tidy libcriterion-dev jq
+git clone --single-branch --branch aws https://github.com/olincollege/ShellWe.git
+cd ShellWe || exit
+mkdir build && cd build || exit
+cmake ..
+make
+cd src/client || exit
+ip_addr="3.130.117.42"
+./ChatClient "$ip_addr"

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+sudo apt update -y
+sudo apt install -y gcc gdb make cmake clang-format \
+clang-tidy libcriterion-dev jq
+cd /home/ubuntu || exit
+git clone https://github.com/olincollege/ShellWe.git
+cd ShellWe || exit
+mkdir build && cd build || exit
+cmake ..
+make
+cd src/server || exit
+ip_addr=$(ip -f inet -o -j addr show eth0 | jq -r '.[].addr_info[].local')
+nohup ./ChatServer "$ip_addr" > server.log 2>&1 &

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -4,7 +4,7 @@ sudo apt update -y
 sudo apt install -y gcc gdb make cmake clang-format \
 clang-tidy libcriterion-dev jq
 cd /home/ubuntu || exit
-git clone https://github.com/olincollege/ShellWe.git
+git clone --single-branch --branch aws https://github.com/olincollege/ShellWe.git
 cd ShellWe || exit
 mkdir build && cd build || exit
 cmake ..

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -9,13 +9,20 @@
 #include "receiver.h"
 
 
-int main(void) {
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s <IP address>\n", argv[0]);
+    return 1;
+  }
+
+  char *ip_address = argv[1];  // IP address passed as command-line argument
+
   char* message = NULL;
   pthread_t recv_thread = 0;
 
   int sock = open_tcp_socket();
 
-  struct sockaddr_in server = socket_address(SERVER_IP, SERVER_PORT);
+  struct sockaddr_in server = socket_address(ip_address, SERVER_PORT);
 
   if (connect(sock, (struct sockaddr*)&server, sizeof(server)) < 0) {
     close_tcp_socket(sock);

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -1,3 +1,4 @@
+#include <arpa/inet.h>
 #include <netinet/in.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -7,7 +8,6 @@
 
 #include "../util/util.h"
 #include "receiver.h"
-
 
 int main(int argc, char *argv[]) {
   if (argc < 2) {
@@ -21,8 +21,8 @@ int main(int argc, char *argv[]) {
   pthread_t recv_thread = 0;
 
   int sock = open_tcp_socket();
-
-  struct sockaddr_in server = socket_address(ip_address, SERVER_PORT);
+  uint32_t ip_addr_converted = ntohl(inet_addr(ip_address));
+  struct sockaddr_in server = socket_address(ip_addr_converted, SERVER_PORT);
 
   if (connect(sock, (struct sockaddr*)&server, sizeof(server)) < 0) {
     close_tcp_socket(sock);

--- a/src/client/receiver.c
+++ b/src/client/receiver.c
@@ -2,6 +2,7 @@
 #include "sys/socket.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include "../util/util.h"
 
 void* receive_message(void* socket_desc) {
   int sock = *(int*)socket_desc;

--- a/src/client/receiver.h
+++ b/src/client/receiver.h
@@ -1,9 +1,3 @@
 #pragma once
 
-enum {
-  RECV_BUFFER_SIZE = 1024,
-  SERVER_IP = 0x7f000001,
-  SERVER_PORT = 12345,
-};
-
 void* receive_message(void* socket_desc);

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -9,7 +9,14 @@
 #include "../util/util.h"
 #include "client_handler.h"
 
-int main(void) {
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s <IP address>\n", argv[0]);
+    return 1;
+  }
+
+  char *ip_address = argv[1];  // IP address passed as command-line argument
+
   int client_sockets[MAX_CLIENTS];
   int* n_clients = malloc(sizeof(int));
   *n_clients = 0;
@@ -20,7 +27,7 @@ int main(void) {
   int socket_desc = open_tcp_socket();
   puts("Socket created");
 
-  struct sockaddr_in server = socket_address(INADDR_LOOPBACK, PORT);
+  struct sockaddr_in server = socket_address(ip_address, PORT);
 
   if (bind(socket_desc, (struct sockaddr*)&server, sizeof(server)) < 0) {
     perror("bind failed. Error");

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -9,14 +9,7 @@
 #include "../util/util.h"
 #include "client_handler.h"
 
-int main(int argc, char *argv[]) {
-  if (argc < 2) {
-    fprintf(stderr, "Usage: %s <IP address>\n", argv[0]);
-    return 1;
-  }
-
-  char *ip_address = argv[1];  // IP address passed as command-line argument
-
+int main(void) {
   int client_sockets[MAX_CLIENTS];
   int* n_clients = malloc(sizeof(int));
   *n_clients = 0;
@@ -27,7 +20,7 @@ int main(int argc, char *argv[]) {
   int socket_desc = open_tcp_socket();
   puts("Socket created");
 
-  struct sockaddr_in server = socket_address(ip_address, PORT);
+  struct sockaddr_in server = socket_address(SERVER_IP, PORT);
 
   if (bind(socket_desc, (struct sockaddr*)&server, sizeof(server)) < 0) {
     perror("bind failed. Error");

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -1,5 +1,6 @@
 #include "util.h"
 
+#include <arpa/inet.h>
 #include <netinet/in.h>
 #include <stdio.h>   // perror
 #include <stdlib.h>  // exit, EXIT_FAILURE
@@ -26,8 +27,8 @@ void close_tcp_socket(int socket_) {
   }
 }
 
-struct sockaddr_in socket_address(in_addr_t addr, in_port_t port) {
-  struct sockaddr_in sockaddr = {.sin_addr = {htonl(addr)},
+struct sockaddr_in socket_address(const char*addr, in_port_t port) {
+  struct sockaddr_in sockaddr = {.sin_addr = {inet_addr(addr)},
                                  .sin_port = htons(port),
                                  .sin_family = AF_INET};
   return sockaddr;

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -1,6 +1,5 @@
 #include "util.h"
 
-#include <arpa/inet.h>
 #include <netinet/in.h>
 #include <stdio.h>   // perror
 #include <stdlib.h>  // exit, EXIT_FAILURE
@@ -27,8 +26,8 @@ void close_tcp_socket(int socket_) {
   }
 }
 
-struct sockaddr_in socket_address(const char*addr, in_port_t port) {
-  struct sockaddr_in sockaddr = {.sin_addr = {inet_addr(addr)},
+struct sockaddr_in socket_address(in_addr_t addr, in_port_t port) {
+  struct sockaddr_in sockaddr = {.sin_addr = {htonl(addr)},
                                  .sin_port = htons(port),
                                  .sin_family = AF_INET};
   return sockaddr;

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define SERVER_IP "0.0.0.0"
+#define SERVER_IP INADDR_ANY
 
 enum {
   RECV_BUFFER_SIZE = 1024,
@@ -57,7 +57,7 @@ void close_tcp_socket(int socket_descriptor);
  * @param port The port number to bind or connect the socket to, in host order.
  * @return A sockaddr_in structure to use with bind/connect, in network order.
  */
-struct sockaddr_in socket_address(const char* addr, in_port_t port);
+struct sockaddr_in socket_address(in_addr_t addr, in_port_t port);
 
 FILE* get_socket_file(int socket);
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#define SERVER_IP "0.0.0.0"
+
+enum {
+  RECV_BUFFER_SIZE = 1024,
+  SERVER_PORT = 12345,
+};
+
 #include <netinet/in.h>   // port, struct sockaddr_in, in_addr_t, in_port_t
 #include <stdio.h>
 #include <stdnoreturn.h>  // noreturn
@@ -50,7 +57,7 @@ void close_tcp_socket(int socket_descriptor);
  * @param port The port number to bind or connect the socket to, in host order.
  * @return A sockaddr_in structure to use with bind/connect, in network order.
  */
-struct sockaddr_in socket_address(in_addr_t addr, in_port_t port);
+struct sockaddr_in socket_address(const char* addr, in_port_t port);
 
 FILE* get_socket_file(int socket);
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,21 @@
+variable "region" {
+  description = "The AWS region in which the resources will be created."
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "availability_zone" {
+  description = "The availability zone where the resources will reside."
+  type        = string
+  default     = "us-east-2b"
+}
+variable "ami" {
+  description = "The ID of the Amazon Machine Image (AMI) used to create the EC2 instance."
+  type        = string
+  default     = "ami-0a125f1b5cba564a0"
+}
+variable "instance_type" {
+  description = "The type of EC2 instance used to create the instance."
+  type        = string
+  default     = "t2.micro"
+}


### PR DESCRIPTION
- Add terraform script to instantiate EC2 instance to host the chat server
- Modify the ChatClient to take ip address of the server as program argument